### PR TITLE
doc: fix http properties documented as methods

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -794,14 +794,14 @@ added: v5.7.0
 A Boolean indicating whether or not the server is listening for
 connections.
 
-### server.maxHeadersCount([limit])
+### server.maxHeadersCount
 <!-- YAML
 added: v0.7.0
 -->
 
-* `limit` {number} Defaults to 1000.
+* {number} Defaults to 2000.
 
-Limits maximum incoming headers count, equal to 1000 by default. If set to 0 -
+Limits maximum incoming headers count, equal to 2000 by default. If set to 0 -
 no limit will be applied.
 
 ### server.setTimeout([msecs][, callback])
@@ -825,12 +825,12 @@ to the Server's `'timeout'` event, timeouts must be handled explicitly.
 
 Returns `server`.
 
-### server.timeout([msecs])
+### server.timeout
 <!-- YAML
 added: v0.9.12
 -->
 
-* `msecs` {number} Defaults to 120000 (2 minutes).
+* {number} Defaults to 120000 (2 minutes).
 
 The number of milliseconds of inactivity before a socket is presumed
 to have timed out.


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines][]

##### Affected core subsystem(s)

- Doc: at 9772fb928263562a755f1aeef6a65620e7e51bf2 [`maxHeadersCount`][maxheaderscount] and [`timeout`][timeout] were erroneously changed to methods
- Doc: `maxHeadersCount` was also listed to default to `1000` where it actually is [`2000`][default]

[maxheaderscount]: https://github.com/nodejs/node/blob/e0a9ad1af244f8756a228a6d087b3a55ee4c0d14/lib/_http_server.js#L276
[timeout]: https://github.com/nodejs/node/blob/e0a9ad1af244f8756a228a6d087b3a55ee4c0d14/lib/_http_server.js#L273
[default]: https://github.com/nodejs/node/blob/e0a9ad1af244f8756a228a6d087b3a55ee4c0d14/lib/_http_server.js#L312


